### PR TITLE
docs: add MacPorts install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ from the official repositories using [Pacman](https://wiki.archlinux.org/title/P
 pacman -S repgrep
 ```
 
+#### Via MacPorts (macOS)
+
+`repgrep` can also be installed on macOS using [MacPorts](https://www.macports.org):
+
+```bash
+sudo port install repgrep
+```
+
+More info [here](https://ports.macports.org/port/repgrep/).
+
 #### From Source (via Cargo)
 
 **NOTE**: The minimum Rust version required is `1.65.0`.


### PR DESCRIPTION
https://ports.macports.org/port/repgrep/